### PR TITLE
feat: Reorder and style header links

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -150,16 +150,16 @@ export const Header: React.FC = () => {
         </div>
         
         <nav className="hidden lg:flex items-center space-x-4 xl:space-x-6">
+          <a href="https://blog.lunarum.app/" className="font-semibold text-slate-200 hover:text-emerald-300 transition-colors duration-200">
+            {t('nav.articles')}
+          </a>
+          <a href="#about" className="font-semibold text-slate-200 hover:text-blue-300 transition-colors duration-200">
+            {t('nav.about')}
+          </a>
           <a href="#support" className="relative group font-medium">
             <span className="bg-gradient-to-r from-yellow-400 via-pink-400 via-purple-400 via-blue-400 to-emerald-400 bg-clip-text text-transparent animate-gradient-x bg-[length:200%_200%]">
               {t('nav.support')}
             </span>
-          </a>
-          <a href="#about" className="text-slate-300 hover:text-blue-300 transition-colors duration-200">
-            {t('nav.about')}
-          </a>
-          <a href="https://blog.lunarum.app/" className="text-slate-300 hover:text-emerald-300 transition-colors duration-200">
-            {t('nav.articles')}
           </a>
           <button 
             onClick={handleAuthAction}
@@ -183,16 +183,16 @@ export const Header: React.FC = () => {
 
         {/* Mobile Nav */}
         <nav className="lg:hidden flex items-center justify-center space-x-6 mt-4 text-sm pb-4 border-b border-slate-800/50 mx-4">
+            <a href="https://blog.lunarum.app/" className="font-semibold text-slate-200 hover:text-emerald-300 transition-colors duration-200">
+                {t('nav.articles')}
+            </a>
+            <a href="#about" className="font-semibold text-slate-200 hover:text-blue-300 transition-colors duration-200">
+                {t('nav.about')}
+            </a>
             <a href="#support" className="relative group font-medium">
                 <span className="bg-gradient-to-r from-yellow-400 via-pink-400 via-purple-400 via-blue-400 to-emerald-400 bg-clip-text text-transparent animate-gradient-x bg-[length:200%_200%]">
                 {t('nav.support')}
                 </span>
-            </a>
-            <a href="#about" className="text-slate-300 hover:text-blue-300 transition-colors duration-200">
-                {t('nav.about')}
-            </a>
-            <a href="https://blog.lunarum.app/" className="text-slate-300 hover:text-emerald-300 transition-colors duration-200">
-                {t('nav.articles')}
             </a>
         </nav>
         


### PR DESCRIPTION
This change reorders the navigation links in the header and applies new styling to make 'Articles' and 'About Us' more prominent, as you requested.

- The new link order is: 'Articles', 'About Us', 'Support Project'.
- 'Articles' and 'About Us' links are now `font-semibold` and have a brighter text color for better visibility.