### PR TITLE
fix: Adjust logo size to prevent shrinking

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -1,0 +1,13 @@
+
+> vite-react-typescript-starter@0.0.0 dev
+> vite
+
+Port 5173 is in use, trying another one...
+Port 5174 is in use, trying another one...
+Port 5175 is in use, trying another one...
+Port 5176 is in use, trying another one...
+
+  VITE v5.4.8  ready in 470 ms
+
+  ➜  Local:   http://localhost:5177/
+  ➜  Network: use --host to expose

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -79,7 +79,7 @@ export const Header: React.FC = () => {
       <header className="relative z-10 px-4 py-6 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         <a href="/" className="flex items-center space-x-3 hover:opacity-80 transition-opacity duration-200">
-          <img src="http://blog.lunarum.app/wp-content/uploads/2025/08/lunarum-logo-big.png" alt="Lunarum" className="h-8 sm:h-10" />
+          <img src="http://blog.lunarum.app/wp-content/uploads/2025/08/lunarum-logo-big.png" alt="Lunarum" className="max-h-12 sm:max-h-16" />
         </a>
         
         {/* Right side controls */}


### PR DESCRIPTION
This change adjusts the styling of the header logo to prevent it from appearing too small, particularly on mobile devices.

- Replaced fixed-height classes (`h-8`, `sm:h-10`) with `max-h-` classes (`max-h-12`, `sm:max-h-16`).
- This allows the logo to render at a larger size while still being constrained within the header, improving its visibility.