### PR TITLE
fix: Add cache-busting query to favicon URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="http://blog.lunarum.app/wp-content/uploads/2025/08/moon.png" />
+    <link rel="icon" type="image/png" href="http://blog.lunarum.app/wp-content/uploads/2025/08/moon.png?v=2" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lunarum ИИ - Раскройте Смыслы За Гранью</title>
     <meta name="description" content="Откройте скрытые смыслы с помощью ИИ-интерпретации снов, персональных гороскопов и мистических таро-раскладов." />


### PR DESCRIPTION
This change adds a version query string to the favicon URL to force browsers to re-download the icon and bypass the cache. This should resolve the issue where the new favicon was not appearing for some users.